### PR TITLE
Fix QA Dependencies and setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["setuptools>=61.0", 'tomli;python_version<"3.11"']
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "radifox-convert"
+dynamic = ["version"]
+description = "A quality assurance webapp for the RADIFOX framework."
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "Apache-2.0"}
+authors = [
+    {name = "JH-MIPC", email = "jhmipc@jh.edu"},
+]
+urls = { "Homepage" = "https://github.com/jh-mipc/radifox-convert" }
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+]
+dependencies = [
+    "nibabel",
+    "numpy",
+    "radifox>=2.1.0",
+    "pydicom",
+]
+
+[project.scripts]
+radifox-convert = "radifox.convert.cli:convert"
+radifox-update = "radifox.convert.cli:update"
+
+[tool.setuptools.packages.find]
+include = ["radifox.*"]
+
+[tool.setuptools.package-data]
+"radifox.convert" = ["parrec_templates/*.txt"]
+
+[miniver]
+package_path = "radifox/convert"

--- a/radifox/convert/base.py
+++ b/radifox/convert/base.py
@@ -12,7 +12,7 @@ from subprocess import run, PIPE, STDOUT
 from typing import Callable, List, Tuple, Union, Any, Optional
 
 import numpy as np
-from radifox.qa.create import create_qa_image
+from radifox.records.qa import create_qa_image
 from radifox.records.hashing import hash_file_dir, hash_file_list, hash_value
 from radifox.records.json import NoIndent, JSONObjectEncoder
 

--- a/setup.py
+++ b/setup.py
@@ -35,16 +35,21 @@ setup(
     packages=find_namespace_packages(include=['radifox.*']),
     entry_points={
         "console_scripts": [
-            "radifox-convert=radifox.conversion.cli:convert",
-            "radifox-update=radifox.conversion.cli:update",
+            "radifox-convert=radifox.convert.cli:convert",
+            "radifox-update=radifox.convert.cli:update",
         ]
     },
     install_requires=[
         "nibabel",
         "numpy",
-        "radifox>=2.0.0",
+        "radifox>=2.1.0",
         "pydicom",
     ],
+    package_data={
+        "radifox.convert": [
+            "parrec_templates/*.txt",
+        ]
+    },
     python_requires=">=3.10",
     include_package_data=True,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,33 @@
-from pathlib import Path
-from setuptools import setup, find_namespace_packages
+from setuptools import setup
 
 
-__package_name__ = "radifox-convert"
-
-
-def get_version_and_cmdclass(pkg_path):
+def get_version_and_cmdclass():
     """Load version.py module without importing the whole package.
 
-    Template code from miniver
+    Template code from miniver altered to use pyproject.toml
     """
     import os
     from importlib.util import module_from_spec, spec_from_file_location
+
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib
+
+    if not os.path.exists(os.path.join("pyproject.toml")):
+        raise FileNotFoundError("pyproject.toml not found. "
+                                "Please use pyproject.toml to define setup.")
+
+    with open("pyproject.toml", "rb") as f:
+        pyproject_data = tomllib.load(f)
+
+    pkg_path = pyproject_data.get("miniver", {}).get("package_path")
+    if pkg_path is None:
+        pkg_path = pyproject_data.get("project", {}).get("name", "")
+
+    if not os.path.exists(os.path.join(pkg_path, "_version.py")):
+        raise FileNotFoundError("_version.py not found. "
+                                "Specify miniver.package_path in pyproject.toml.")
 
     spec = spec_from_file_location("version", os.path.join(pkg_path, "_version.py"))
     module = module_from_spec(spec)
@@ -19,42 +35,10 @@ def get_version_and_cmdclass(pkg_path):
     return module.__version__, module.get_cmdclass(pkg_path)
 
 
-__version__, cmdclass = get_version_and_cmdclass('radifox/convert')
+__version__, cmdclass = get_version_and_cmdclass()
+
 
 setup(
-    name=__package_name__,
     version=__version__,
     cmdclass=cmdclass,
-    author="JH-MIPC",
-    author_email="jhmipc@jh.edu",
-    url="https://github.com/jh-mipc/radifox-convert",
-    description="Conversion tools using the RADIFOX framework.",
-    long_description=(Path(__file__).parent.resolve() / "README.md").read_text(),
-    long_description_content_type="text/markdown",
-    license="Apache License, 2.0",
-    packages=find_namespace_packages(include=['radifox.*']),
-    entry_points={
-        "console_scripts": [
-            "radifox-convert=radifox.convert.cli:convert",
-            "radifox-update=radifox.convert.cli:update",
-        ]
-    },
-    install_requires=[
-        "nibabel",
-        "numpy",
-        "radifox>=2.1.0",
-        "pydicom",
-    ],
-    package_data={
-        "radifox.convert": [
-            "parrec_templates/*.txt",
-        ]
-    },
-    python_requires=">=3.10",
-    include_package_data=True,
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: Apache Software License",
-        "Operating System :: OS Independent",
-    ],
 )


### PR DESCRIPTION
This PR fixes the qa dependencies after the split from the main repository. This should be merged after the main repository changes have been merged and the version has been successfully updated to v2.1.0.

Additional fixes in the `setup.py` file to use the correct naming after the split from the main repo and get the parrec templates in place.