### PR TITLE
Dockerfile install from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,11 @@ ARG DEBIAN_VERSION
 ENV PYTHONUSERBASE=/opt/python
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends git && \
+    apt-get install -y --no-install-recommends git dcm2niix && \
     rm -rf /var/lib/apt/lists/*
+
+# Install radifox from source
+RUN pip install --no-cache-dir git+https://github.com/jh-mipc/radifox.git
 
 COPY . /tmp/src
 RUN pip install --no-cache-dir /tmp/src && rm -rf /tmp/src


### PR DESCRIPTION
Install radifox from source with Docker

radifox-convert requires radifox>=2.1.0, but PyPI only has up to 1.3.0
Without this, build fails with:
ERROR: Could not find a version that satisfies the requirement radifox>=2.1.0
ERROR: No matching distribution found for radifox>=2.1.0