### PR TITLE
anonymize database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,5 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+# Anonymous database
+*.db

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For a full listing of command line options, see [Advanced CLI Usage](#advanced-c
 The `radifox-convert` script is used to convert DICOM files to NIfTI files using the `dcm2niix` tool.
 It is a wrapper around `dcm2niix` that uses the RADIFOX naming system to organize the output files.
 
-Example Usage:
+**Single subject conversion:**
 ```bash
 radifox-convert \
     --output-root /path/to/output \
@@ -47,6 +47,27 @@ radifox-convert \
 ```
 This will copy the files in the direction `/path/to/dicom_files` to the output directory `/path/to/output/study/123456/STUDY-1/dcm`, organize them and convert them to NIfTI.
 The NIfTI files (and their JSON sidecar files) will be placed in `/path/to/output/study/STUDY-123456/1/nii`.
+
+**Anonymized conversion** (`--anonymize`):
+
+By default, anonymization with `--anonymize` is **irreversible**.
+Identifiers are hashed, UIDs are randomized, dates are shifted (if `--date-shift-days` is set), and copied DICOM/PARREC source files are permanently deleted.
+No mapping between original and anonymized identifiers is retained.
+
+If you need the ability to reverse anonymization later, you must explicitly opt in by providing `--anon-db` to store a mapping database:
+```bash
+radifox-convert \
+    --output-root /path/to/output \
+    --project-id study \
+    --subject-id 123456 \
+    --session-id 1 \
+    --anonymize \
+    --anon-db /path/to/mapping.db \
+    --date-shift-days 42 \
+    /path/to/dicom_files
+```
+The mapping database records the original `PatientID`, `PatientName`, `PatientBirthDate`, `PatientSex`, source path, original Study UID, Institution Name, and date shift days.
+This database should be stored securely and separately from the converted output, as it contains the link between anonymized and original identifiers.
 
 #### `radifox-update`
 The `radifox-update` script is used to update naming for a directory of images.
@@ -60,6 +81,39 @@ radifox-update --directory /path/to/output/study/STUDY-123456/1
 This will update the naming for all images in the existing RADIFOX session directory `/path/to/output/study/STUDY-123456/1`.
 If the RADIFOX version, look-up table, or manual naming entries have changed, the images will be renamed to reflect the new information.
 If none of these have changed, the update will be skipped.
+
+**De-anonymization** (`--deanonymize`):
+
+The `--deanonymize` flag reverses anonymization using the mapping database created by `--anon-db`.
+It renames directories, files, and patches JSON sidecar metadata to restore original patient identifiers.
+
+What is restored:
+- Subject directories and filenames are renamed from anonymous IDs back to original `PatientID`
+- `SubjectID` in JSON sidecar metadata
+- `SourcePath` in JSON sidecar series entries
+- Original `InstitutionName` (un-hashed)
+- Original `StudyUID` (un-randomized)
+- Acquisition dates (date shift reversed, if applicable)
+
+What cannot be restored:
+- Raw DICOM/PARREC files (permanently deleted during anonymized conversion)
+
+```bash
+# De-anonymize all subjects
+radifox-convert \
+    --output-root /path/to/output \
+    --project-id study \
+    --anon-db /path/to/mapping.db \
+    --deanonymize
+
+# De-anonymize a single patient
+radifox-convert \
+    --output-root /path/to/output \
+    --project-id study \
+    --anon-db /path/to/mapping.db \
+    --deanonymize \
+    --subject 123456
+```
 
 # Conversion
 The conversion system is a wrapper around the `dcm2niix` tool.
@@ -149,7 +203,7 @@ Any output that is returned from the `run` method will have a QA image generated
 ### `radifox-convert`
 | Option                      | Description                                                                                                                            | Default                                           |
 |-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------|
-| `source`                    | The source directory (or zip file) containing the DICOM files.                                                                         | `required`                                        |
+| `source`                    | The source directory (or zip file) containing the DICOM files. Not required with `--deanonymize`.                                      | `required`                                        |
 | `-o`, `--output-root`       | The root directory for the output files (contains project directories).                                                                | `required`                                        |
 | `-p`, `--project-id`        | The project ID for the converted session.                                                                                              | `required`                                        |
 | `-s`, `--subject-id`        | The subject ID for the converted session.                                                                                              | `required`                                        |
@@ -168,8 +222,11 @@ Any output that is returned from the `run` method will have a QA image generated
 | `--parrec`                  | Convert PAR/REC files instead of DICOM files.                                                                                          | `False`                                           |
 | `--institution`             | The institution name to use for the session (required for PAR/REC conversion).                                                         | `None`                                            |
 | `--field-strength`          | The magnetic field strength to use for the session (required for PAR/REC conversion).                                                  | `None`                                            |
-| `--anonymize`               | Experimental anonymization support (will remove copied DICOM files).                                                                   | `False`                                           |
+| `--anonymize`               | Anonymize output (irreversible unless `--anon-db` is also provided). Hashes identifiers, randomizes UIDs, removes copied source files. | `False`                                           |
 | `--date-shift-days`         | The number of days to shift the date by during anonymization.                                                                          | `None`                                            |
+| `--anon-db`                 | Path to SQLite anonymization mapping database. Records original patient identifiers for later de-anonymization. Requires `--anonymize`. | `None`                                            |
+| `--deanonymize`             | Reverse anonymization using the mapping database. Requires `--anon-db` and `--project-id`.                                             | `False`                                           |
+| `--subject`                 | De-anonymize only this patient ID (only with `--deanonymize`).                                                                         | `None` (all subjects)                             |
 | `--tms-metafile`            | The TMS metafile to use for subject, site and session ID.                                                                              | `None`                                            |
 | `--force-derived`           | Convert derived/secondary DICOM series that would normally be skipped (e.g., images converted from NIfTI back to DICOM).               | `False`                                           |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "numpy",
     "radifox>=2.1.0",
     "pydicom",
+    "sqlalchemy",
 ]
 
 [project.scripts]

--- a/radifox/convert/anondb.py
+++ b/radifox/convert/anondb.py
@@ -1,0 +1,156 @@
+import errno
+import secrets
+from datetime import datetime
+from pathlib import Path
+from types import TracebackType
+
+from sqlalchemy import ForeignKey, String, create_engine
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship, sessionmaker
+
+
+class Base(DeclarativeBase):
+    """SQLAlchemy declarative base class for type checking."""
+
+    pass
+
+
+class Subject(Base):
+    """SQLAlchemy model representing an anonymized subject mapping."""
+
+    __tablename__ = "subjects"
+
+    anon_id: Mapped[str] = mapped_column(String, primary_key=True)
+    patient_id: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+    patient_name: Mapped[str | None] = mapped_column(String, nullable=True)
+    patient_birth_date: Mapped[str | None] = mapped_column(String, nullable=True)
+    patient_sex: Mapped[str | None] = mapped_column(String, nullable=True)
+    date_shift_days: Mapped[int | None] = mapped_column(nullable=True)
+    created_at: Mapped[datetime | None] = mapped_column(default=datetime.now)
+
+    sessions: Mapped[list["Session"]] = relationship("Session", back_populates="subject")
+
+
+class Session(Base):
+    """SQLAlchemy model representing a single conversion session for a subject."""
+
+    __tablename__ = "sessions"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    anon_id: Mapped[str] = mapped_column(String, ForeignKey("subjects.anon_id"), nullable=False)
+    session_id: Mapped[str] = mapped_column(String, nullable=False)
+    source_path: Mapped[str | None] = mapped_column(String, nullable=True)
+    original_study_uid: Mapped[str | None] = mapped_column(String, nullable=True)
+    institution_name: Mapped[str | None] = mapped_column(String, nullable=True)
+    converted_at: Mapped[datetime | None] = mapped_column(default=datetime.now)
+
+    subject: Mapped["Subject"] = relationship("Subject", back_populates="sessions")
+
+
+class AnonDB:
+    """Interface to the SQLite anonymization mapping database."""
+
+    def __init__(self, db_path: Path):
+        """Open or create the database at the given path."""
+        try:
+            self.engine = create_engine(f"sqlite:///{db_path}")
+            Base.metadata.create_all(self.engine)
+            self._Session = sessionmaker(bind=self.engine)
+            self.session = self._Session()
+        except PermissionError as e:
+            raise RuntimeError(f"Permission denied: cannot access database at {db_path}") from e
+        except OSError as e:
+            if e.errno == errno.ENOSPC:
+                raise RuntimeError(f"Disk full: cannot create database at {db_path}") from e
+            raise RuntimeError(f"Cannot open database at {db_path}: {e}") from e
+        except OperationalError as e:
+            raise RuntimeError(f"Database error at {db_path}: {e}") from e
+
+    def __enter__(self) -> "AnonDB":
+        """Support use as a context manager."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Close the database when exiting the context manager."""
+        self.close()
+
+    def get_or_create_subject(
+        self,
+        patient_id: str,
+        patient_name: str | None = None,
+        patient_birth_date: str | None = None,
+        patient_sex: str | None = None,
+        date_shift_days: int | None = None,
+        anon_id: str | None = None,
+    ) -> str:
+        """Look up a subject by patient_id, or create a new one.
+
+        If anon_id is provided it is used as the anonymous ID, otherwise a
+        random one is generated. Returns the anon_id."""
+        subject = self.session.query(Subject).filter_by(patient_id=patient_id).first()
+        if subject is not None:
+            return subject.anon_id
+
+        if anon_id is None:
+            # Generate unique anon_id (collision extremely unlikely with 64 bits)
+            anon_id = secrets.token_hex(8)
+            while self.session.query(Subject).filter_by(anon_id=anon_id).first() is not None:
+                anon_id = secrets.token_hex(8)
+
+        subject = Subject(
+            anon_id=anon_id,
+            patient_id=patient_id,
+            patient_name=patient_name,
+            patient_birth_date=patient_birth_date,
+            patient_sex=patient_sex,
+            date_shift_days=date_shift_days,
+        )
+        self.session.add(subject)
+        return anon_id
+
+    def add_session(
+        self,
+        anon_id: str,
+        source_path: str,
+        original_study_uid: str | None = None,
+        institution_name: str | None = None,
+    ) -> str:
+        """Record a new conversion session for a subject. The session_id is
+        auto-incremented per subject. Returns the session_id string."""
+        count = self.session.query(Session).filter_by(anon_id=anon_id).count()
+        session_id = str(count + 1)
+        sess = Session(
+            anon_id=anon_id,
+            session_id=session_id,
+            source_path=source_path,
+            original_study_uid=original_study_uid,
+            institution_name=institution_name,
+        )
+        self.session.add(sess)
+        return session_id
+
+    def get_all_subjects(self) -> list[Subject]:
+        """Return all subject records from the database."""
+        return self.session.query(Subject).all()
+
+    def get_sessions_for_subject(self, anon_id: str) -> list[Session]:
+        """Return all session records for a given anonymous subject ID."""
+        return self.session.query(Session).filter_by(anon_id=anon_id).all()
+
+    def commit(self) -> None:
+        """Commit the current transaction."""
+        self.session.commit()
+
+    def rollback(self) -> None:
+        """Roll back the current transaction."""
+        self.session.rollback()
+
+    def close(self) -> None:
+        """Close the database session and dispose of the engine."""
+        self.session.close()
+        self.engine.dispose()

--- a/radifox/convert/cli.py
+++ b/radifox/convert/cli.py
@@ -5,18 +5,70 @@ from pathlib import Path
 import shutil
 from typing import List, Optional
 
+from pydicom import dcmread
+from pydicom.dataset import Dataset, FileDataset
+from pydicom.errors import InvalidDicomError
+
 from radifox.records.hashing import hash_file_dir
 
 from ._version import __version__
+from .anondb import AnonDB
+from .deanon import deanonymize_subject
 from .exec import run_conversion, ExecError
 from .lut import LookupTable
 from .metadata import Metadata
 from .utils import silentremove, mkdir_p, version_check
 
 
+def _extract_patient_info(ds: Dataset | FileDataset) -> dict:
+    """Extract patient-level DICOM attributes from a pydicom Dataset."""
+    return {
+        "patient_id": getattr(ds, "PatientID", None),
+        "patient_name": str(getattr(ds, "PatientName", "")) or None,
+        "patient_birth_date": getattr(ds, "PatientBirthDate", None),
+        "patient_sex": getattr(ds, "PatientSex", None),
+        "study_uid": getattr(ds, "StudyInstanceUID", None),
+        "institution_name": getattr(ds, "InstitutionName", None),
+    }
+
+
+def _find_first_dicom(directory: Path):
+    """Walk a directory to find and read the first valid DICOM file."""
+    for f in sorted(directory.rglob("*")):
+        if f.is_file():
+            try:
+                ds = dcmread(f, stop_before_pixels=True)
+                return ds
+            except (InvalidDicomError, Exception):
+                continue
+    return None
+
+
+def _run_deanonymize(args: argparse.Namespace) -> None:
+    """Reverse anonymization using the mapping database."""
+    project_id = args.project_id.upper()
+    project_dir = args.output_root / project_id.lower()
+
+    if not project_dir.exists():
+        raise ValueError("Project directory does not exist: %s" % project_dir)
+
+    with AnonDB(args.anon_db) as db:
+        subjects = db.get_all_subjects()
+        if args.subject:
+            subjects = [s for s in subjects if s.patient_id == args.subject]
+            if not subjects:
+                raise ValueError("Patient ID '%s' not found in database." % args.subject)
+
+        for subject in subjects:
+            sessions = db.get_sessions_for_subject(subject.anon_id)
+            deanonymize_subject(project_dir, project_id, subject, sessions)
+
+    print("\n--- De-anonymized %d subject(s) ---" % len(subjects))
+
+
 def convert(args: Optional[List[str]] = None) -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("source", type=Path, help="Source directory/file to convert.")
+    parser.add_argument("source", type=Path, nargs="?", help="Source directory/file to convert.")
     parser.add_argument(
         "-o", "--output-root", type=Path, help="Output root directory.", required=True
     )
@@ -61,16 +113,60 @@ def convert(args: Optional[List[str]] = None) -> None:
         help="Convert derived/secondary DICOM series that would normally be skipped.",
         default=False,
     )
-    parser.add_argument("--anonymize", action="store_true", help="Anonymize DICOM data.")
+    parser.add_argument(
+        "--anonymize",
+        action="store_true",
+        help="Anonymize DICOM data (irreversible unless --anon-db is also provided).",
+    )
     parser.add_argument("--date-shift-days", type=int, help="Number of days to shift dates.")
+    parser.add_argument(
+        "--anon-db",
+        type=Path,
+        help="Path to SQLite anonymization mapping database. "
+        "Records original patient identifiers for later de-anonymization. "
+        "Requires --anonymize.",
+    )
+    parser.add_argument(
+        "--deanonymize",
+        action="store_true",
+        help="Reverse anonymization using the mapping database "
+        "(requires --anon-db and --project-id).",
+    )
+    parser.add_argument(
+        "--subject",
+        type=str,
+        help="De-anonymize only this patient ID (only with --deanonymize).",
+    )
     parser.add_argument("--version", action="version", version="%(prog)s " + __version__)
 
     args = parser.parse_args(args)
 
-    for argname in ["source", "output_root", "lut_file", "tms_metafile"]:
-        if getattr(args, argname) is not None:
+    for argname in ["source", "output_root", "lut_file", "tms_metafile", "anon_db"]:
+        if getattr(args, argname, None) is not None:
             setattr(args, argname, getattr(args, argname).resolve())
 
+    # --- Deanonymize mode ---
+    if args.deanonymize:
+        if args.anon_db is None:
+            raise ValueError("--deanonymize requires --anon-db.")
+        if args.project_id is None:
+            raise ValueError("--deanonymize requires --project-id.")
+        _run_deanonymize(args)
+        return
+
+    if args.subject:
+        raise ValueError("--subject is only valid with --deanonymize.")
+
+    if args.source is None:
+        raise ValueError("source is required (omit only with --deanonymize).")
+
+    if args.anon_db is not None and not args.anonymize:
+        raise ValueError("--anon-db requires --anonymize.")
+
+    if args.date_shift_days is not None and not args.anonymize:
+        raise ValueError("--date-shift-days requires --anonymize.")
+
+    # --- Standard conversion ---
     if args.hardlink and args.symlink:
         raise ValueError("Only one of --symlink and --hardlink can be used.")
     linking = "hardlink" if args.hardlink else ("symlink" if args.symlink else None)
@@ -166,6 +262,12 @@ def convert(args: Optional[List[str]] = None) -> None:
         "InstitutionName": args.institution,
     }
 
+    # If --anon-db is provided, read DICOM patient info before conversion
+    # (source files may be removed during anonymized conversion)
+    if args.anon_db is not None:
+        ds = _find_first_dicom(args.source) if args.source.is_dir() else None
+        patient_info = _extract_patient_info(ds) if ds is not None else {}
+
     run_conversion(
         args.source,
         args.output_root,
@@ -183,6 +285,26 @@ def convert(args: Optional[List[str]] = None) -> None:
         None,
         args.force_derived,
     )
+
+    # Record mapping in anonymization database after successful conversion
+    if args.anon_db is not None:
+        with AnonDB(args.anon_db) as db:
+            anon_id = db.get_or_create_subject(
+                patient_id=patient_info.get("patient_id") or metadata.SubjectID,
+                patient_name=patient_info.get("patient_name"),
+                patient_birth_date=patient_info.get("patient_birth_date"),
+                patient_sex=patient_info.get("patient_sex"),
+                date_shift_days=args.date_shift_days,
+                anon_id=metadata.SubjectID,
+            )
+            db.add_session(
+                anon_id=anon_id,
+                source_path=str(args.source),
+                original_study_uid=patient_info.get("study_uid"),
+                institution_name=patient_info.get("institution_name"),
+            )
+            db.commit()
+        print("Recorded mapping in %s (subject %s)" % (args.anon_db, anon_id))
 
 
 def update(args: Optional[List[str]] = None) -> None:

--- a/radifox/convert/deanon.py
+++ b/radifox/convert/deanon.py
@@ -1,0 +1,99 @@
+import json
+from pathlib import Path
+
+from .anondb import Session, Subject
+from .utils import shift_date
+
+
+def _patch_json_sidecar(json_file: Path, patient_id: str, session: Session, subject: Subject) -> bool:
+    """Patch a single JSON sidecar file to restore original patient identifiers.
+
+    Returns True if the file was changed.
+    """
+    json_obj = json.loads(json_file.read_text())
+    changed = False
+
+    if "Metadata" in json_obj:
+        json_obj["Metadata"]["SubjectID"] = patient_id
+        json_obj["RemoveIdentifiers"] = False
+        changed = True
+
+    if "SeriesList" in json_obj:
+        for series in json_obj["SeriesList"]:
+            if session.source_path and series.get("SourcePath") is None:
+                series["SourcePath"] = session.source_path
+                changed = True
+            if session.institution_name is not None:
+                series["InstitutionName"] = session.institution_name
+                changed = True
+            if session.original_study_uid is not None:
+                series["StudyUID"] = session.original_study_uid
+                changed = True
+            if subject.date_shift_days and series.get("AcqDateTime"):
+                series["AcqDateTime"] = shift_date(series["AcqDateTime"], -subject.date_shift_days)
+                changed = True
+
+    if changed:
+        json_file.write_text(json.dumps(json_obj, indent=4, sort_keys=True))
+        print(f"  Patched {json_file.name}")
+
+    return changed
+
+
+def _rename_files(directory: Path, old_prefix: str, new_prefix: str, label: str = "") -> None:
+    """Rename all files in a directory that start with old_prefix to use new_prefix."""
+    if old_prefix == new_prefix:
+        return
+    prefix = (f"  {label}") if label else " "
+    for filepath in sorted(directory.iterdir()):
+        if filepath.name.startswith(old_prefix):
+            new_name = filepath.name.replace(old_prefix, new_prefix, 1)
+            new_path = directory / new_name
+            if new_path.exists():
+                print(f" {prefix}Skipping {filepath.name}: target {new_name} already exists")
+                continue
+            filepath.rename(new_path)
+            print(f" {prefix}Renamed {filepath.name} -> {new_name}")
+
+
+def deanonymize_subject(project_dir: Path, project_id: str, subject: Subject, sessions: list[Session]) -> None:
+    """De-anonymize a single subject: patch JSONs, rename files, rename directory."""
+    anon_id_upper = subject.anon_id.upper()
+    patient_id_upper = subject.patient_id.upper()
+    anon_dir_name = f"{project_id}-{anon_id_upper}"
+    new_dir_name = f"{project_id}-{patient_id_upper}"
+    anon_subject_dir = project_dir / anon_dir_name
+
+    if not anon_subject_dir.exists():
+        print(f"Skipping {anon_dir_name}: directory not found.")
+        return
+
+    print(f"{anon_dir_name} -> {new_dir_name}")
+
+    for sess in sessions:
+        session_dir = anon_subject_dir / sess.session_id
+        if not session_dir.exists():
+            continue
+
+        anon_prefix = f"{project_id}-{anon_id_upper}_{sess.session_id}"
+        new_prefix = f"{project_id}-{patient_id_upper}_{sess.session_id}"
+
+        for json_file in session_dir.glob("*.json"):
+            _patch_json_sidecar(json_file, patient_id_upper, sess, subject)
+
+        _rename_files(session_dir, anon_prefix, new_prefix)
+
+        nii_dir = session_dir / "nii"
+        if nii_dir.exists():
+            _rename_files(nii_dir, anon_prefix, new_prefix, label="nii/")
+
+        qa_dir = session_dir / "qa"
+        if qa_dir.exists():
+            for qa_subdir in sorted(qa_dir.iterdir()):
+                if qa_subdir.is_dir():
+                    _rename_files(qa_subdir, anon_prefix, new_prefix, label="qa/%s/" % qa_subdir.name)
+
+    if anon_dir_name != new_dir_name:
+        new_subject_dir = project_dir / new_dir_name
+        anon_subject_dir.rename(new_subject_dir)
+        print(f"  Renamed directory {anon_dir_name} -> {new_dir_name}")

--- a/radifox/convert/utils.py
+++ b/radifox/convert/utils.py
@@ -269,6 +269,8 @@ def version_check(saved_version: str, current_version: str) -> bool:
 
 
 def shift_date(datetime_str: str, date_shift_days: int = 0) -> str:
+    if not date_shift_days:
+        return datetime_str
     orig_date = datetime.strptime(datetime_str, "%Y-%m-%d %H:%M:%S")
     return (orig_date + timedelta(days=date_shift_days)).strftime("%Y-%m-%d %H:%M:%S")
 


### PR DESCRIPTION
New --batch mode — Treat source as a parent directory containing subject subdirectories; automatically uses PatientID from DICOM headers as subject ID

New --anon-db option — SQLite database to store reversible anonymization mappings (patient IDs → random anonymous IDs, original UIDs, institution names, date shifts). Implies batch mode.

New --deanonymize flag — Reverse anonymization using the mapping database; restores original patient IDs, directory names, JSON metadata, and acquisition dates